### PR TITLE
Rename Art to Extras and add updating to specific nightlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 TWiLightMenu Updater is an open-source updater for TWiLightMenu++
 
 # Links
-[TWiLightMenu++](https://github.com/RocketRobz/TWiLightMenu)
+[TWiLightMenu++](https://github.com/DS-Homebrew/TWiLightMenu)
 
 [nds-bootstrap](https://github.com/ahezard/nds-bootstrap)
 

--- a/source/download.cpp
+++ b/source/download.cpp
@@ -1131,8 +1131,8 @@ void scanToCancelBoxArt(void) {
 	}
 }
 
-void downloadArt(void) {
-	std::string artOptions[] = {"Boxart", "Themes"};
+void downloadExtras(void) {
+	std::string extrasOptions[] = {"Boxart", "Themes"};
 	int selectedOption = 0;
 	while(1) {
 		gspWaitForVBlank();
@@ -1155,17 +1155,17 @@ void downloadArt(void) {
 				selectedOption++;
 			}
 		}
-		std::string artText = "Would you like to download boxart\nor themes?\n";
+		std::string extrasText = "What would you like to download?\n";
 		for(int i=0;i<2;i++) {
 			if(i == selectedOption) {
-				artText += "> " + artOptions[i] + "\n";
+				extrasText += "> " + extrasOptions[i] + "\n";
 			} else {
-				artText += "  " + artOptions[i] + "\n";
+				extrasText += "  " + extrasOptions[i] + "\n";
 			}
 		}
-		artText += "\n\n\n\n\n\n\n";
-		artText += "B: Back   A: Choose";
-		displayBottomMsg(artText.c_str());
+		extrasText += "\n\n\n\n\n\n\n\n";
+		extrasText += "B: Back   A: Choose";
+		displayBottomMsg(extrasText.c_str());
 	}
 }
 

--- a/source/download.hpp
+++ b/source/download.hpp
@@ -28,8 +28,9 @@ Result downloadFromRelease(std::string url, std::string asset, std::string path)
  * @return True if Wi-Fi is connected; false if not.
  */
 bool checkWifiStatus(void);
+
 /**
- * Display "Please connect to Wi-Fi" for 2s
+ * Display "Please connect to Wi-Fi" for 2s.
  */
 void notConnectedMsg(void);
 
@@ -69,14 +70,17 @@ std::vector<ThemeEntry> getThemeList(std::string repo, std::string path);
 /**
  * Show the latest release's name and message.
  * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
+ * drawMessageText is whether to show the Cancel/Update text at the bottom
  */
 bool showReleaseInfo(std::string repo, bool drawMessageText);
 
 /**
  * Show the latest commit's name and message.
- * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
+ * repo is where to get from. (Ex. "TWlBot/Builds")
+ * title is what the commit title needs to start with (Ex. "TWiLightMenu")
+ * drawMessageText is whether to show the Cancel/Update text at the bottom
  */
-std::string chooseCommit(std::string repo, bool showExitText);
+std::string chooseCommit(std::string repo, std::string title, bool showExitText);
 
 /**
  * Prepare text for showing a release/commit message.
@@ -97,18 +101,21 @@ void checkForUpdates(void);
 
 /**
  * Update nds-bootstrap to the latest build.
+ * commit is the TWlBot commit, leave blank for release
  */
-void updateBootstrap(bool nightly);
+void updateBootstrap(std::string commit);
 
 /**
  * Update TWiLight Menu++ to the latest build.
+ * commit is the TWlBot commit, leave blank for release
  */
-void updateTWiLight(bool nightly);
+void updateTWiLight(std::string commit);
 
 /**
  * Update the TWiLight Menu++ Updater to the latest build.
+ * commit is the TWlBot commit, leave blank for release
  */
-void updateSelf(bool nightly);
+void updateSelf(std::string commit);
 
 /**
  * Update DeadSkullzJr's cheat DB to the latest version.

--- a/source/download.hpp
+++ b/source/download.hpp
@@ -118,7 +118,7 @@ void updateCheats(void);
 /**
  * Display a menu to choose to download boxart or themes.
  */
-void downloadArt(void);
+void downloadExtras(void);
 
 /**
  * Download boxart from gametdb for all roms found on SD.

--- a/source/download.hpp
+++ b/source/download.hpp
@@ -35,7 +35,7 @@ void notConnectedMsg(void);
 
 /**
  * Get info from the GitHub API about a Release.
- * repo is where to get from. (Ex. "RocketRobz/TWiLightMenu")
+ * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
  * item is that to get from the API. (Ex. "tag_name")
  * @return the string from the API.
  */
@@ -43,20 +43,20 @@ std::string getLatestRelease(std::string repo, std::string item);
 
 /**
  * Get info from the GitHub API about a Commit.
- * repo is where to get from. (Ex. "RocketRobz/TWiLightMenu")
+ * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
  * item is that to get from the API. (Ex. "sha")
  * @return the string from the API.
  */
-std::string getLatestCommit(std::string repo, std::string item);
+std::vector<std::string> getRecentCommits(std::string repo, std::string item);
 
 /**
  * Get info from the GitHub API about a Commit.
- * repo is where to get from. (Ex. "RocketRobz/TWiLightMenu")
+ * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
  * array is the array the item is in. (Ex. "commit")
  * item is that to get from the API. (Ex. "message")
  * @return the string from the API.
  */
-std::string getLatestCommit(std::string repo, std::string array, std::string item);
+std::vector<std::string> getRecentCommits(std::string repo, std::string array, std::string item);
 
 /**
  * Get a GitHub directory's contents with the GitHub API.
@@ -68,15 +68,15 @@ std::vector<ThemeEntry> getThemeList(std::string repo, std::string path);
 
 /**
  * Show the latest release's name and message.
- * repo is where to get from. (Ex. "RocketRobz/TWiLightMenu")
+ * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
  */
 bool showReleaseInfo(std::string repo, bool drawMessageText);
 
 /**
  * Show the latest commit's name and message.
- * repo is where to get from. (Ex. "RocketRobz/TWiLightMenu")
+ * repo is where to get from. (Ex. "DS-Homebrew/TWiLightMenu")
  */
-void showCommitInfo(std::string repo);
+std::string chooseCommit(std::string repo, bool showExitText);
 
 /**
  * Prepare text for showing a release/commit message.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -369,7 +369,7 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					chooseCommit("DS-Homebrew/TWiLightMenu", false);
+					chooseCommit("TWLBot/Builds", "TWiLightMenu |", false);
 					break;
 				case 2:
 					if(dspfirmfound) {
@@ -383,7 +383,7 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					chooseCommit("ahezard/nds-bootstrap", false);
+					chooseCommit("TWLBot/Builds", "nds-bootstrap |", false);
 					break;
 				case 4:
 					if(dspfirmfound) {
@@ -397,7 +397,7 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					chooseCommit("DS-Homebrew/TWiLightMenu-Updater", false);
+					chooseCommit("TWLBot/Builds", "TWiLightMenu-Updater |", false);
 					break;
 				default:
 					if(dspfirmfound) {
@@ -411,52 +411,48 @@ int main()
 
 		if (setOption) {
 			if(checkWifiStatus()) {
+				std::string commit;
 				switch (menuSelection) {
 					case 0:	// TWiLight release
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading release notes...");
 						if(showReleaseInfo("DS-Homebrew/TWiLightMenu", true))
-							updateTWiLight(false);
+							updateTWiLight("");
 						break;
 					case 1:	// TWiLight nightly
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading commits...");
-						if(chooseCommit("DS-Homebrew/TWiLightMenu", true) != "")
-							updateTWiLight(true);
+						if((commit = chooseCommit("TWLBot/Builds", "TWiLightMenu |", true)) != "")
+							updateTWiLight(commit);
 						break;
 					case 2:	// nds-bootstrap release
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading release notes...");
 						if(showReleaseInfo("ahezard/nds-bootstrap", true))
-							updateBootstrap(false);
+							updateBootstrap("");
 						break;
 					case 3:	// nds-bootstrap nightly
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading commits...");
-						if(chooseCommit("ahezard/nds-bootstrap", true) != "")
-							updateBootstrap(true);
+						if((commit = chooseCommit("TWLBot/Builds", "nds-bootstrap |", true)) != "")
+							updateBootstrap(commit);
 						break;
 					case 4:	// Updater release
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading release notes...");
 						if(showReleaseInfo("DS-Homebrew/TWiLightMenu-Updater", true)) {
 							updatingSelf = true;
-							updateSelf(false);
+							updateSelf("");
 							updatingSelf = false;
 						}
 						break;
@@ -465,10 +461,9 @@ int main()
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						displayBottomMsg("Loading commits...");
-						if(chooseCommit("DS-Homebrew/TWiLightMenu", true) != "") {
+						if((commit = chooseCommit("TWLBot/Builds", "TWiLightMenu-Updater |", true)) != "") {
 							updatingSelf = true;
-							updateSelf(true);
+							updateSelf(commit);
 							updatingSelf = false;
 						}
 						break;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -362,14 +362,14 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showReleaseInfo("RocketRobz/TWiLightMenu", false);
+					showReleaseInfo("DS-Homebrew/TWiLightMenu", false);
 					break;
 				case 1:
 					if(dspfirmfound) {
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showCommitInfo("RocketRobz/TWiLightMenu");
+					chooseCommit("DS-Homebrew/TWiLightMenu", false);
 					break;
 				case 2:
 					if(dspfirmfound) {
@@ -383,21 +383,21 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showCommitInfo("ahezard/nds-bootstrap");
+					chooseCommit("ahezard/nds-bootstrap", false);
 					break;
 				case 4:
 					if(dspfirmfound) {
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showReleaseInfo("RocketRobz/TWiLightMenu-Updater", false);
+					showReleaseInfo("DS-Homebrew/TWiLightMenu-Updater", false);
 					break;
 				case 5:
 					if(dspfirmfound) {
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showCommitInfo("RocketRobz/TWiLightMenu-Updater");
+					chooseCommit("DS-Homebrew/TWiLightMenu-Updater", false);
 					break;
 				default:
 					if(dspfirmfound) {
@@ -418,7 +418,7 @@ int main()
 							sfx_select->play();
 						}
 						displayBottomMsg("Loading release notes...");
-						if(showReleaseInfo("RocketRobz/TWiLightMenu", true))
+						if(showReleaseInfo("DS-Homebrew/TWiLightMenu", true))
 							updateTWiLight(false);
 						break;
 					case 1:	// TWiLight nightly
@@ -426,7 +426,9 @@ int main()
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						updateTWiLight(true);
+						displayBottomMsg("Loading commits...");
+						if(chooseCommit("DS-Homebrew/TWiLightMenu", true) != "")
+							updateTWiLight(true);
 						break;
 					case 2:	// nds-bootstrap release
 						if(dspfirmfound) {
@@ -442,7 +444,9 @@ int main()
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						updateBootstrap(true);
+						displayBottomMsg("Loading commits...");
+						if(chooseCommit("ahezard/nds-bootstrap", true) != "")
+							updateBootstrap(true);
 						break;
 					case 4:	// Updater release
 						if(dspfirmfound) {
@@ -450,7 +454,7 @@ int main()
 							sfx_select->play();
 						}
 						displayBottomMsg("Loading release notes...");
-						if(showReleaseInfo("RocketRobz/TWiLightMenu-Updater", true)) {
+						if(showReleaseInfo("DS-Homebrew/TWiLightMenu-Updater", true)) {
 							updatingSelf = true;
 							updateSelf(false);
 							updatingSelf = false;
@@ -461,9 +465,12 @@ int main()
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						updatingSelf = true;
-						updateSelf(true);
-						updatingSelf = false;
+						displayBottomMsg("Loading commits...");
+						if(chooseCommit("DS-Homebrew/TWiLightMenu", true) != "") {
+							updatingSelf = true;
+							updateSelf(true);
+							updatingSelf = false;
+						}
 						break;
 					case 6:	// Cheats
 						break;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,14 +6,14 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include "graphic.h"
-#include "pp2d/pp2d.h"
-#include "sound.h"
-#include "dumpdsp.h"
-#include "settings.h"
-#include "language.h"
 #include "download.hpp"
+#include "dumpdsp.h"
+#include "graphic.h"
 #include "inifile.h"
+#include "language.h"
+#include "pp2d/pp2d.h"
+#include "settings.h"
+#include "sound.h"
 
 #define CONFIG_3D_SLIDERSTATE (*(float *)0x1FF81080)
 
@@ -68,8 +68,8 @@ const char *button_titles2[] = {
 	"Nightly",
 	"Release",
 	"Nightly",
-	"Art",
 	"Cheats",
+	"Extras",
 };
 
 const int title_spacing[] = {
@@ -79,8 +79,8 @@ const int title_spacing[] = {
 	10,
 	6,
 	10,
-	30,
 	10,
+	17,
 };
 
 const char *row_titles2[] = {
@@ -205,7 +205,7 @@ int main()
 		sfx_wrong = new sound("romfs:/sounds/wrong.wav", 2, false);
 		sfx_back = new sound("romfs:/sounds/back.wav", 2, false);
 	}
-	
+
 	bool buttonShading = false;
 	bool setOption = false;
 	bool showMessage = false;
@@ -465,19 +465,20 @@ int main()
 						updateSelf(true);
 						updatingSelf = false;
 						break;
-					case 6:	// Art
-						if(dspfirmfound) {
-							sfx_select->stop();
-							sfx_select->play();
-						}
-						downloadArt();
+					case 6:	// Cheats
 						break;
-					case 7:	// usrcheat.dat
 						if(dspfirmfound) {
 							sfx_select->stop();
 							sfx_select->play();
 						}
 						updateCheats();
+						break;
+					case 7:	// Extras
+						if(dspfirmfound) {
+							sfx_select->stop();
+							sfx_select->play();
+						}
+						downloadExtras();
 						break;
 					default:
 						if(dspfirmfound) {


### PR DESCRIPTION
This PR:
- Renames `Art` to `Extras` and swaps it with `Cheats`
- Adds updating to specific nightlies (Fixes #48)
  - *Note:* Currently it only shows the TWLBot commit notes as TWLBot's commit shas in the commit notes are bugged and show the previous TWLBot commit, not the source commit, so I can't know what commit to show the notes for
- (Not actually but I want to close the issue since I fixed it a couple PR's ago) fixes #58 