### PR TITLE
Fix chrashing on boot on a real 3DS (not Citra)

### DIFF
--- a/source/download.cpp
+++ b/source/download.cpp
@@ -838,13 +838,13 @@ std::string latestBootstrapNightly(void) {
 
 std::string latestUpdaterRelease(void) {
 	if (latestUpdaterReleaseCache == "")
-		latestUpdaterReleaseCache = getLatestRelease("DS-Homebrew/TWiLightMenu-Updater", "tag_name");
+		latestUpdaterReleaseCache = getLatestRelease("RocketRobz/TWiLightMenu-Updater", "tag_name");
 	return latestUpdaterReleaseCache;
 }
 
 std::string latestUpdaterNightly(void) {
 	if (latestUpdaterNightlyCache == "")
-		latestUpdaterNightlyCache = getRecentCommits("DS-Homebrew/TWiLightMenu-Updater", "sha")[0].substr(0,7);
+		latestUpdaterNightlyCache = getRecentCommits("RocketRobz/TWiLightMenu-Updater", "sha")[0].substr(0,7);
 	return latestUpdaterNightlyCache;
 }
 
@@ -1044,7 +1044,7 @@ void updateSelf(std::string commit) {
 		showProgressBar = true;
 		progressBarType = 0;
 		createThread((ThreadFunc)displayProgressBar);
-		if (downloadFromRelease("https://github.com/DS-Homebrew/TWiLightMenu-Updater", "TWiLightMenu-Updater\\.cia", "/TWiLightMenu-Updater-release.cia") != 0) {
+		if (downloadFromRelease("https://github.com/RocketRobz/TWiLightMenu-Updater", "TWiLightMenu-Updater\\.cia", "/TWiLightMenu-Updater-release.cia") != 0) {
 			downloadFailed();
 			return;
 		}
@@ -1082,7 +1082,7 @@ void updateSelf(std::string commit) {
 		showProgressBar = true;
 		progressBarType = 0;
 		createThread((ThreadFunc)displayProgressBar);
-		if (downloadFromRelease("https://github.com/DS-Homebrew/TWiLightMenu-Updater", "TWiLightMenu-Updater\\.3dsx", "/3ds/TWiLightMenu-Updater.3dsx") != 0) {
+		if (downloadFromRelease("https://github.com/RocketRobz/TWiLightMenu-Updater", "TWiLightMenu-Updater\\.3dsx", "/3ds/TWiLightMenu-Updater.3dsx") != 0) {
 			downloadFailed();
 			return;
 		}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -390,7 +390,7 @@ int main()
 						sfx_select->stop();
 						sfx_select->play();
 					}
-					showReleaseInfo("DS-Homebrew/TWiLightMenu-Updater", false);
+					showReleaseInfo("RocketRobz/TWiLightMenu-Updater", false);
 					break;
 				case 5:
 					if(dspfirmfound) {
@@ -450,7 +450,7 @@ int main()
 							sfx_select->stop();
 							sfx_select->play();
 						}
-						if(showReleaseInfo("DS-Homebrew/TWiLightMenu-Updater", true)) {
+						if(showReleaseInfo("RocketRobz/TWiLightMenu-Updater", true)) {
 							updatingSelf = true;
 							updateSelf("");
 							updatingSelf = false;


### PR DESCRIPTION
I accidentally changed the repo name for this to `DS-Homebrew/TWiLightMenu-Updater` which was causing crashes on real hardware. (Citra was fine, so I didn't notice before)

- Fixes #65 