### PR TITLE
Download png boxart files (Fixes #68)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ steps:
 - script: |
     git config --global user.email "flamekat54@aol.com"
     git config --global user.name "TWLBot"
-    git --depth 1 clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
+    git clone --depth 1 https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
     cd Builds/TWiLightMenu\ Updater/
     cp ../../TWiLight_Menu++_Updater.3dsx TWiLight_Menu++_Updater.3dsx
     cp ../../TWiLight_Menu++_Updater.cia TWiLight_Menu++_Updater.cia

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,37 +15,37 @@ variables:
 
 steps:
 - script: |
-     curl -L https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb -o pacman.deb
-     sudo apt update
-     sudo apt install p7zip-full haveged
-     sudo dpkg -i pacman.deb
-     sudo dkp-pacman -Sy
-     sudo dkp-pacman -S 3ds-dev --noconfirm
-     sudo dkp-pacman -S 3ds-curl 3ds-libarchive 3ds-liblzma 3ds-mbedtls 3ds-bzip2 3ds-zlib --noconfirm
-     sudo 7z x libctru.7z -o/opt/devkitpro/ -y
-     curl -L https://github.com/Steveice10/bannertool/releases/download/1.1.0/bannertool.zip -o bannertool.zip
-     sudo 7z e bannertool.zip linux-x86_64/bannertool
-     sudo chmod +x bannertool
-     rm bannertool.zip
-     curl -L https://github.com/profi200/Project_CTR/releases/download/0.15/makerom_015_ctrtool.zip -o makerom_015_ctrtool.zip
-     sudo 7z e makerom_015_ctrtool.zip Linux_x86_64/makerom
-     sudo chmod +x makerom
-     rm makerom_015_ctrtool.zip
+    curl -L https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb -o pacman.deb
+    sudo apt update
+    sudo apt install p7zip-full haveged
+    sudo dpkg -i pacman.deb
+    sudo dkp-pacman -Sy
+    sudo dkp-pacman -S 3ds-dev --noconfirm
+    sudo dkp-pacman -S 3ds-curl 3ds-libarchive 3ds-liblzma 3ds-mbedtls 3ds-bzip2 3ds-zlib --noconfirm
+    sudo 7z x libctru.7z -o/opt/devkitpro/ -y
+    curl -L https://github.com/Steveice10/bannertool/releases/download/1.1.0/bannertool.zip -o bannertool.zip
+    sudo 7z e bannertool.zip linux-x86_64/bannertool
+    sudo chmod +x bannertool
+    rm bannertool.zip
+    curl -L https://github.com/profi200/Project_CTR/releases/download/0.15/makerom_015_ctrtool.zip -o makerom_015_ctrtool.zip
+    sudo 7z e makerom_015_ctrtool.zip Linux_x86_64/makerom
+    sudo chmod +x makerom
+    rm makerom_015_ctrtool.zip
   displayName: 'Setup devkitPro'
   
 - script: |
-     export PATH=$PATH:$(pwd)
-     export DEVKITPRO="/opt/devkitpro"
-     export DEVKITARM="/opt/devkitpro/devkitARM"
-     make
+    export PATH=$PATH:$(pwd)
+    export DEVKITPRO="/opt/devkitpro"
+    export DEVKITARM="/opt/devkitpro/devkitARM"
+    make
+    echo '##vso[task.setvariable variable=COMMIT_TAG]'$(git log --format=%h -1)
+    echo '##vso[task.setvariable variable=COMMIT_MESSAGE]'$(git log --pretty=format:"%an - %s" -1)
   displayName: 'Build TWiLightMenu-Updater'
 
 - script: |
-    echo '##vso[task.setvariable variable=COMMIT_TAG]'$(git log --format=%h -1)
-    echo '##vso[task.setvariable variable=COMMIT_MESSAGE]'$(git log --pretty=format:"%an - %s" -1)
     git config --global user.email "flamekat54@aol.com"
     git config --global user.name "TWLBot"
-    git clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
+    git --depth 1 clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
     cd Builds/TWiLightMenu\ Updater/
     cp ../../TWiLight_Menu++_Updater.3dsx TWiLight_Menu++_Updater.3dsx
     cp ../../TWiLight_Menu++_Updater.cia TWiLight_Menu++_Updater.cia

--- a/source/download.cpp
+++ b/source/download.cpp
@@ -1351,31 +1351,44 @@ void downloadBoxart(void) {
 	findNdsFiles(dirContents);
 	continueNdsScan = false;
 
+	mkdir("sdmc:/_nds/TWiLightMenu/boxart/temp", 0777);
 	for(int i=0;i<(int)dirContents.size();i++) {
-		char downloadMessage[50];
-		snprintf(downloadMessage, sizeof(downloadMessage), "Downloading \"%s.png\"...\n", dirContents[i].tid);
-		displayBottomMsg(downloadMessage);
+		char path[256];
+		snprintf(path, sizeof(path), "sdmc:/_nds/TWiLightMenu/boxart/%s.png", dirContents[i].tid);
+		if(access(path, F_OK) != 0) {
+			char downloadMessage[50];
+			snprintf(downloadMessage, sizeof(downloadMessage), "Downloading \"%s.png\"...\n", dirContents[i].tid);
+			displayBottomMsg(downloadMessage);
 
-		const char *ba_region = getBoxartRegion(dirContents[i].tid[3]);
-		
-		char boxartUrl[256];
-		snprintf(boxartUrl, sizeof(boxartUrl), "https://art.gametdb.com/ds/coverS/%s/%s.png", ba_region, dirContents[i].tid);
-		char boxartPath[256];
-		snprintf(boxartPath, sizeof(boxartPath), "/_nds/TWiLightMenu/boxart/%s.png", dirContents[i].tid);
-		
-		downloadToFile(boxartUrl, boxartPath);
+			const char *ba_region = getBoxartRegion(dirContents[i].tid[3]);
+			
+			char boxartUrl[256];
+			snprintf(boxartUrl, sizeof(boxartUrl), "https://art.gametdb.com/ds/coverS/%s/%s.png", ba_region, dirContents[i].tid);
+			char boxartPath[256];
+			snprintf(boxartPath, sizeof(boxartPath), "/_nds/TWiLightMenu/boxart/temp/%s.png", dirContents[i].tid);
+			
+			downloadToFile(boxartUrl, boxartPath);
+		}
 	}
 
-	chdir("sdmc:/_nds/TWiLightMenu/boxart/");
+	chdir("sdmc:/_nds/TWiLightMenu/boxart/temp/");
 	getDirectoryContents(dirContents);
 
-	displayBottomMsg("Deleting blank files...");
+	displayBottomMsg("Cleaning up...");
 	for(int i=0;i<(int)dirContents.size();i++) {
 		if(dirContents[i].size == 0) {
 			char path[256];
-			snprintf(path, sizeof(path), "%s%s", "sdmc:/_nds/TWiLightMenu/boxart/", dirContents[i].name.c_str());
+			snprintf(path, sizeof(path), "sdmc:/_nds/TWiLightMenu/boxart/temp/%s", dirContents[i].name.c_str());
 			deleteFile(path);
+		} else {
+			char tempPath[256];
+			snprintf(tempPath, sizeof(tempPath), "sdmc:/_nds/TWiLightMenu/boxart/temp/%s", dirContents[i].name.c_str());
+			char path[256];
+			snprintf(path, sizeof(path), "sdmc:/_nds/TWiLightMenu/boxart/%s", dirContents[i].name.c_str());
+			deleteFile(path);
+			rename(tempPath, path);
 		}
+		rmdir("sdmc:/_nds/TWiLightMenu/boxart/temp");
 	}
 	doneMsg();
 }

--- a/source/download.cpp
+++ b/source/download.cpp
@@ -1353,15 +1353,15 @@ void downloadBoxart(void) {
 
 	for(int i=0;i<(int)dirContents.size();i++) {
 		char downloadMessage[50];
-		snprintf(downloadMessage, sizeof(downloadMessage), "Downloading \"%s.bmp\"...\n", dirContents[i].tid);
+		snprintf(downloadMessage, sizeof(downloadMessage), "Downloading \"%s.png\"...\n", dirContents[i].tid);
 		displayBottomMsg(downloadMessage);
 
 		const char *ba_region = getBoxartRegion(dirContents[i].tid[3]);
 		
 		char boxartUrl[256];
-		snprintf(boxartUrl, sizeof(boxartUrl), "https://art.gametdb.com/ds/coverDS/%s/%s.bmp", ba_region, dirContents[i].tid);
+		snprintf(boxartUrl, sizeof(boxartUrl), "https://art.gametdb.com/ds/coverS/%s/%s.png", ba_region, dirContents[i].tid);
 		char boxartPath[256];
-		snprintf(boxartPath, sizeof(boxartPath), "/_nds/TWiLightMenu/boxart/%s.bmp", dirContents[i].tid);
+		snprintf(boxartPath, sizeof(boxartPath), "/_nds/TWiLightMenu/boxart/%s.png", dirContents[i].tid);
 		
 		downloadToFile(boxartUrl, boxartPath);
 	}


### PR DESCRIPTION
This PR:
- Changes the boxart downloading from bmp files to png files (Fixes #68)
- Makes it skip boxart that's already downloaded (Fixes #47)
- Doesn't replace existing boxart if the download fails (Fixes #70)
  - Now that I think about it, this is unnecessary with the previous point... Oh well, it doesn't hurt...
- This also updates `azure-pipelines.yml` to use the correct commit sha when committing